### PR TITLE
Update view.py

### DIFF
--- a/discord/ui/view.py
+++ b/discord/ui/view.py
@@ -381,7 +381,7 @@ class View:
         """
         pass
 
-    async def on_error(self, error: Exception, item: Item[Any], interaction: Interaction) -> None:
+    async def on_error(self, error: Exception, interaction: Interaction, item: Item[Any]) -> None:
         """|coro|
 
         A callback that is called when an item's callback or :meth:`interaction_check`
@@ -393,10 +393,10 @@ class View:
         -----------
         error: :class:`Exception`
             The exception that was raised.
-        item: :class:`Item`
-            The item that failed the dispatch.
         interaction: :class:`~discord.Interaction`
             The interaction that led to the failure.
+        item: :class:`Item`
+            The item that failed the dispatch.
         """
         print(f'Ignoring exception in view {self} for item {item}:', file=sys.stderr)
         traceback.print_exception(error.__class__, error, error.__traceback__, file=sys.stderr)
@@ -412,7 +412,7 @@ class View:
 
             await item.callback(interaction)
         except Exception as e:
-            return await self.on_error(e, item, interaction)
+            return await self.on_error(e, interaction, item)
 
     def _start_listening_from_store(self, store: ViewStore) -> None:
         self.__cancel_callback = partial(store.remove_view)


### PR DESCRIPTION
## Summary

According to [this message](https://discord.com/channels/336642139381301249/381965829857738772/958229416536858684) the order for arguments of callbacks inside Views should be `interaction, item`. This corrects the order in the View.on_error.

If I missed something or it was intentional, let me know!

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
